### PR TITLE
Resolvendo Problema de tipagem em PrismaEcopointRepository e PrismaSubscriberRepository

### DIFF
--- a/backend/src/infrastructure/database/prisma/PrismaEcopointRepository.ts
+++ b/backend/src/infrastructure/database/prisma/PrismaEcopointRepository.ts
@@ -5,6 +5,8 @@ import { CollectionTime } from "../../../domain/value-objects/CollectionTime.js"
 import { AcceptedMaterials } from "../../../domain/value-objects/AcceptedMaterials.js";
 import { Address } from "../../../domain/value-objects/Address.js";
 import { CollectionDays } from "../../../domain/value-objects/CollectionDays.js";
+import { PostalCode } from "../../../domain/value-objects/PostalCode.js";
+import { GeoLocation } from "../../../domain/value-objects/GeoLocation.js";
 
 export class PrismaEcopointRepository implements EcopointRepository {
     constructor(private prisma: PrismaClient) { }
@@ -21,9 +23,9 @@ export class PrismaEcopointRepository implements EcopointRepository {
                 street: data.address.getStreet(),
                 number: data.address.getNumber(),
                 complement: data.address.getComplement(),
-                postal_code: data.address.getPostalCode(),
-                latitude: data.address.getLatitude(),
-                longitude: data.address.getLongitude(),
+                postal_code: data.address.getPostalCode()?.getValue(),
+                latitude: data.address.getGeoLocation()?.getLatitude(),
+                longitude: data.address.getGeoLocation()?.getLongitude(),
                 accepted_materials: data.accepted_materials.toString(),
                 collection_days: data.collection_days.toString(),
                 collection_time: data.collection_time.getFormattedInterval(),
@@ -41,9 +43,10 @@ export class PrismaEcopointRepository implements EcopointRepository {
                 street: createdEcopoint.street,
                 number: createdEcopoint.number ?? undefined,
                 complement: createdEcopoint.complement ?? undefined,
-                postalCode: createdEcopoint.postal_code ?? undefined,
-                latitude: createdEcopoint.latitude ?? undefined,
-                longitude: createdEcopoint.longitude ?? undefined,
+                postalCode: createdEcopoint.postal_code ? new PostalCode(createdEcopoint.postal_code) : undefined,
+                geoLocation: (createdEcopoint.latitude !== null && createdEcopoint.longitude !== null)
+                    ? new GeoLocation(createdEcopoint.latitude, createdEcopoint.longitude)
+                    : undefined,
             }),
             CollectionDays.fromString(createdEcopoint.collection_days),
             this.parseCollectionTime(createdEcopoint.collection_time),
@@ -70,9 +73,10 @@ export class PrismaEcopointRepository implements EcopointRepository {
                 street: ecopoint.street,
                 number: ecopoint.number ?? undefined,
                 complement: ecopoint.complement ?? undefined,
-                postalCode: ecopoint.postal_code ?? undefined,
-                latitude: ecopoint.latitude ?? undefined,
-                longitude: ecopoint.longitude ?? undefined,
+                postalCode: ecopoint.postal_code ? new PostalCode(ecopoint.postal_code) : undefined,
+                geoLocation: (ecopoint.latitude !== null && ecopoint.longitude !== null)
+                    ? new GeoLocation(ecopoint.latitude, ecopoint.longitude)
+                    : undefined,
             }),
             CollectionDays.fromString(ecopoint.collection_days),
             this.parseCollectionTime(ecopoint.collection_time),
@@ -97,9 +101,10 @@ export class PrismaEcopointRepository implements EcopointRepository {
                         street: ecopoint.street,
                         number: ecopoint.number ?? undefined,
                         complement: ecopoint.complement ?? undefined,
-                        postalCode: ecopoint.postal_code ?? undefined,
-                        latitude: ecopoint.latitude ?? undefined,
-                        longitude: ecopoint.longitude ?? undefined,
+                        postalCode: ecopoint.postal_code ? new PostalCode(ecopoint.postal_code) : undefined,
+                        geoLocation: (ecopoint.latitude !== null && ecopoint.longitude !== null)
+                            ? new GeoLocation(ecopoint.latitude, ecopoint.longitude)
+                            : undefined,
                     }),
                     CollectionDays.fromString(ecopoint.collection_days),
                     this.parseCollectionTime(ecopoint.collection_time),
@@ -127,9 +132,10 @@ export class PrismaEcopointRepository implements EcopointRepository {
                         street: ecopoint.street,
                         number: ecopoint.number ?? undefined,
                         complement: ecopoint.complement ?? undefined,
-                        postalCode: ecopoint.postal_code ?? undefined,
-                        latitude: ecopoint.latitude ?? undefined,
-                        longitude: ecopoint.longitude ?? undefined,
+                        postalCode: ecopoint.postal_code ? new PostalCode(ecopoint.postal_code) : undefined,
+                        geoLocation: (ecopoint.latitude !== null && ecopoint.longitude !== null)
+                            ? new GeoLocation(ecopoint.latitude, ecopoint.longitude)
+                            : undefined,
                     }),
                     CollectionDays.fromString(ecopoint.collection_days),
                     this.parseCollectionTime(ecopoint.collection_time),
@@ -150,9 +156,9 @@ export class PrismaEcopointRepository implements EcopointRepository {
                 street: data.address?.getStreet(),
                 number: data.address?.getNumber(),
                 complement: data.address?.getComplement(),
-                postal_code: data.address?.getPostalCode(),
-                latitude: data.address?.getLatitude(),
-                longitude: data.address?.getLongitude(),
+                postal_code: data.address?.getPostalCode()?.getValue(),
+                latitude: data.address?.getGeoLocation()?.getLatitude(),
+                longitude: data.address?.getGeoLocation()?.getLongitude(),
                 accepted_materials: data.accepted_materials?.toString(),
                 collection_days: data.collection_days?.toString(),
                 collection_time: data.collection_time?.getFormattedInterval(),
@@ -170,9 +176,10 @@ export class PrismaEcopointRepository implements EcopointRepository {
                 street: updatedEcopoint.street,
                 number: updatedEcopoint.number ?? undefined,
                 complement: updatedEcopoint.complement ?? undefined,
-                postalCode: updatedEcopoint.postal_code ?? undefined,
-                latitude: updatedEcopoint.latitude ?? undefined,
-                longitude: updatedEcopoint.longitude ?? undefined,
+                postalCode: updatedEcopoint.postal_code ? new PostalCode(updatedEcopoint.postal_code) : undefined,
+                geoLocation: (updatedEcopoint.latitude !== null && updatedEcopoint.longitude !== null)
+                    ? new GeoLocation(updatedEcopoint.latitude, updatedEcopoint.longitude)
+                    : undefined,
             }),
             CollectionDays.fromString(updatedEcopoint.collection_days),
             this.parseCollectionTime(updatedEcopoint.collection_time),

--- a/backend/src/infrastructure/database/prisma/PrismaSubscriberRepository.ts
+++ b/backend/src/infrastructure/database/prisma/PrismaSubscriberRepository.ts
@@ -3,6 +3,8 @@ import { Subscriber } from "../../../domain/entities/Subscriber.js";
 import { SubscriberRepository } from "../../../domain/repositories/SubscriberRepository.js";
 import { Email } from "../../../domain/value-objects/Email.js";
 import { Address } from "../../../domain/value-objects/Address.js";
+import { PostalCode } from "../../../domain/value-objects/PostalCode.js";
+import { GeoLocation } from "../../../domain/value-objects/GeoLocation.js";
 
 export class PrismaSubscriberRepository implements SubscriberRepository {
     constructor(private prisma: PrismaClient) { }
@@ -14,9 +16,9 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                 street: data.address.getStreet(),
                 number: data.address.getNumber(),
                 complement: data.address.getComplement(),
-                postal_code: data.address.getPostalCode(),
-                latitude: data.address.getLatitude(),
-                longitude: data.address.getLongitude(),
+                postal_code: data.address.getPostalCode()?.getValue(),
+                latitude: data.address.getGeoLocation()?.getLatitude(),
+                longitude: data.address.getGeoLocation()?.getLongitude(),
                 neighborhood_id: data.neighborhood_id,
             },
         });
@@ -28,9 +30,10 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                 street: createdSubscriber.street,
                 number: createdSubscriber.number ?? undefined,
                 complement: createdSubscriber.complement ?? undefined,
-                postalCode: createdSubscriber.postal_code ?? undefined,
-                latitude: createdSubscriber.latitude ?? undefined,
-                longitude: createdSubscriber.longitude ?? undefined,
+                postalCode: createdSubscriber.postal_code ? new PostalCode(createdSubscriber.postal_code) : undefined,
+                geoLocation: (createdSubscriber.latitude !== null && createdSubscriber.longitude !== null)
+                    ? new GeoLocation(createdSubscriber.latitude, createdSubscriber.longitude)
+                    : undefined,
             }),
             createdSubscriber.neighborhood_id,
             createdSubscriber.created_at,
@@ -52,9 +55,10 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                 street: subscriber.street,
                 number: subscriber.number ?? undefined,
                 complement: subscriber.complement ?? undefined,
-                postalCode: subscriber.postal_code ?? undefined,
-                latitude: subscriber.latitude ?? undefined,
-                longitude: subscriber.longitude ?? undefined,
+                postalCode: subscriber.postal_code ? new PostalCode(subscriber.postal_code) : undefined,
+                geoLocation: (subscriber.latitude !== null && subscriber.longitude !== null)
+                    ? new GeoLocation(subscriber.latitude, subscriber.longitude)
+                    : undefined,
             }),
             subscriber.neighborhood_id,
             subscriber.created_at,
@@ -76,9 +80,10 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                 street: subscriber.street,
                 number: subscriber.number ?? undefined,
                 complement: subscriber.complement ?? undefined,
-                postalCode: subscriber.postal_code ?? undefined,
-                latitude: subscriber.latitude ?? undefined,
-                longitude: subscriber.longitude ?? undefined,
+                postalCode: subscriber.postal_code ? new PostalCode(subscriber.postal_code) : undefined,
+                geoLocation: (subscriber.latitude !== null && subscriber.longitude !== null)
+                    ? new GeoLocation(subscriber.latitude, subscriber.longitude)
+                    : undefined,
             }),
             subscriber.neighborhood_id,
             subscriber.created_at,
@@ -98,9 +103,10 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                         street: subscriber.street,
                         number: subscriber.number ?? undefined,
                         complement: subscriber.complement ?? undefined,
-                        postalCode: subscriber.postal_code ?? undefined,
-                        latitude: subscriber.latitude ?? undefined,
-                        longitude: subscriber.longitude ?? undefined,
+                        postalCode: subscriber.postal_code ? new PostalCode(subscriber.postal_code) : undefined,
+                        geoLocation: (subscriber.latitude !== null && subscriber.longitude !== null)
+                            ? new GeoLocation(subscriber.latitude, subscriber.longitude)
+                            : undefined,
                     }),
                     subscriber.neighborhood_id,
                     subscriber.created_at,
@@ -123,9 +129,10 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                         street: subscriber.street,
                         number: subscriber.number ?? undefined,
                         complement: subscriber.complement ?? undefined,
-                        postalCode: subscriber.postal_code ?? undefined,
-                        latitude: subscriber.latitude ?? undefined,
-                        longitude: subscriber.longitude ?? undefined,
+                        postalCode: subscriber.postal_code ? new PostalCode(subscriber.postal_code) : undefined,
+                        geoLocation: (subscriber.latitude !== null && subscriber.longitude !== null)
+                            ? new GeoLocation(subscriber.latitude, subscriber.longitude)
+                            : undefined,
                     }),
                     subscriber.neighborhood_id,
                     subscriber.created_at,
@@ -142,9 +149,9 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                 street: data.address?.getStreet(),
                 number: data.address?.getNumber(),
                 complement: data.address?.getComplement(),
-                postal_code: data.address?.getPostalCode(),
-                latitude: data.address?.getLatitude(),
-                longitude: data.address?.getLongitude(),
+                postal_code: data.address?.getPostalCode()?.getValue(),
+                latitude: data.address?.getGeoLocation()?.getLatitude(),
+                longitude: data.address?.getGeoLocation()?.getLongitude(),
                 neighborhood_id: data.neighborhood_id,
             },
         });
@@ -156,9 +163,10 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                 street: updatedSubscriber.street,
                 number: updatedSubscriber.number ?? undefined,
                 complement: updatedSubscriber.complement ?? undefined,
-                postalCode: updatedSubscriber.postal_code ?? undefined,
-                latitude: updatedSubscriber.latitude ?? undefined,
-                longitude: updatedSubscriber.longitude ?? undefined,
+                postalCode: updatedSubscriber.postal_code ? new PostalCode(updatedSubscriber.postal_code) : undefined,
+                geoLocation: (updatedSubscriber.latitude !== null && updatedSubscriber.longitude !== null)
+                    ? new GeoLocation(updatedSubscriber.latitude, updatedSubscriber.longitude)
+                    : undefined,
             }),
             updatedSubscriber.neighborhood_id,
             updatedSubscriber.created_at,


### PR DESCRIPTION
### 🔨 Alterações realizadas

### Repositórios ``PrismaEcopointRepository`` e ``PrismaSubscriberRepository``

- O **Value Object** *Address* estava utilizando tipos primitivos para os campos de ``cep`` e ``localização``: (latitude e longitude)
- Reutilizamos os **Value Objects** que haviam sido criados anteriormente: **_PostalCode_** e **_GeoLocation_.**

### 📌 Observações
- Código compilando sem erros.
- Artefatos atualizados e validados.
- Refatoração concluída com sucesso, mantendo compatibilidade com o schema atual e alinhamento com boas práticas de domínio.