### PR TITLE
Padronizando o nome dos campos (CamelCase x SnakeCase)

### DIFF
--- a/backend/src/domain/entities/Administrator.ts
+++ b/backend/src/domain/entities/Administrator.ts
@@ -1,12 +1,12 @@
 import { Email } from "../value-objects/Email.js";
 
 export class Administrator {
-    constructor(
-      public readonly id: number,
-      public name: string,
-      public email: Email,
-      public password?: string,
-      public readonly creation_date?: Date,
-      public readonly update_date?: Date
-    ) {}
+  constructor(
+    public readonly id: number,
+    public name: string,
+    public email: Email,
+    public password?: string,
+    public readonly creationDate?: Date,
+    public readonly updateDate?: Date
+  ) { }
 }

--- a/backend/src/domain/entities/Ecopoint.ts
+++ b/backend/src/domain/entities/Ecopoint.ts
@@ -7,14 +7,14 @@ export class Ecopoint {
     constructor(
         public readonly id: number,
         public name: string,
-        public accepted_materials: AcceptedMaterials,
+        public acceptedMaterials: AcceptedMaterials,
         public address: Address,
-        public collection_days: CollectionDays,
-        public collection_time: CollectionTime,
-        public neighborhood_id: number,
-        public admin_id_created: number,
-        public admin_id_updated: number | null,
-        public readonly created_at: Date,
-        public readonly updated_at: Date
+        public collectionDays: CollectionDays,
+        public collectionTime: CollectionTime,
+        public neighborhoodId: number,
+        public adminIdCreated: number,
+        public adminIdUpdated: number | null,
+        public readonly createdAt: Date,
+        public readonly updatedAt: Date
     ) { }
 }

--- a/backend/src/domain/entities/Neighborhood.ts
+++ b/backend/src/domain/entities/Neighborhood.ts
@@ -9,10 +9,10 @@ export class Neighborhood {
     public populationEstimate: PopulationEstimate,
     public postalCode: PostalCode,
     public geoLocation: GeoLocation,
-    public readonly created_at: Date,
-    public readonly updated_at: Date,
-    public route_id: number,
-    public admin_id_created: number,
-    public admin_id_updated: number | null
-  ) {}
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+    public routeId: number,
+    public adminIdCreated: number,
+    public adminIdUpdated: number | null
+  ) { }
 }

--- a/backend/src/domain/entities/ProblemReport.ts
+++ b/backend/src/domain/entities/ProblemReport.ts
@@ -12,9 +12,9 @@ export class ProblemReport {
     public status: ProblemStatus,
     public description: ProblemDescription,
     public problemType: ProblemType,
-    public readonly created_at: Date,
-    public readonly updated_at: Date,
-    public subscriber_id: number,
-    public resolved_by_admin_id: number | null
-  ) {}
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+    public subscriberId: number,
+    public resolvedByAdminId: number | null
+  ) { }
 }

--- a/backend/src/domain/entities/Route.ts
+++ b/backend/src/domain/entities/Route.ts
@@ -6,12 +6,12 @@ export class Route {
   constructor(
     public readonly id: number,
     public name: string,
-    public collection_days: CollectionDays,
-    public collection_time: CollectionTime,
-    public collection_type: CollectionType,
-    public created_at: Date,
-    public updated_at: Date,
-    public admin_id_created: number,
-    public admin_id_updated: number | null
-  ) {}
+    public collectionDays: CollectionDays,
+    public collectionTime: CollectionTime,
+    public collectionType: CollectionType,
+    public createdAt: Date,
+    public updatedAt: Date,
+    public adminIdCreated: number,
+    public adminIdUpdated: number | null
+  ) { }
 }

--- a/backend/src/domain/entities/Subscriber.ts
+++ b/backend/src/domain/entities/Subscriber.ts
@@ -6,8 +6,8 @@ export class Subscriber {
         public readonly id: number,
         public email: Email,
         public address: Address,
-        public neighborhood_id: number,
-        public readonly created_at: Date,
-        public readonly updated_at: Date
+        public neighborhoodId: number,
+        public readonly createdAt: Date,
+        public readonly updatedAt: Date
     ) { }
 }

--- a/backend/src/domain/repositories/AdministratorRepository.ts
+++ b/backend/src/domain/repositories/AdministratorRepository.ts
@@ -2,10 +2,10 @@ import { Email } from "../value-objects/Email.js";
 import { Administrator } from "../entities/Administrator.js";
 
 export interface AdministratorRepository {
-  create(admin: Omit<Administrator, "id" | "creation_date" | "update_date">): Promise<Administrator>;
+  create(admin: Omit<Administrator, "id" | "creationDate" | "updateDate">): Promise<Administrator>;
   findByEmail(email: Email): Promise<Administrator | null>;
   findById(id: number): Promise<Administrator | null>;
   findAll(): Promise<Administrator[]>;
-  update(id: number, data: Partial<Omit<Administrator, "id" | "creation_date">>): Promise<Administrator>;
+  update(id: number, data: Partial<Omit<Administrator, "id" | "creationDate">>): Promise<Administrator>;
   delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/EcopointRepository.ts
+++ b/backend/src/domain/repositories/EcopointRepository.ts
@@ -1,10 +1,10 @@
 import { Ecopoint } from "../entities/Ecopoint.js";
 
 export interface EcopointRepository {
-    create(data: Omit<Ecopoint, "id" | "created_at" | "updated_at">): Promise<Ecopoint>;
+    create(data: Omit<Ecopoint, "id" | "createdAt" | "updatedAt">): Promise<Ecopoint>;
     findById(id: number): Promise<Ecopoint | null>;
     findAll(): Promise<Ecopoint[]>;
     findByNeighborhoodId(neighborhoodId: number): Promise<Ecopoint[]>;
-    update(id: number, data: Partial<Omit<Ecopoint, "id" | "created_at">>): Promise<Ecopoint>;
+    update(id: number, data: Partial<Omit<Ecopoint, "id" | "createdAt">>): Promise<Ecopoint>;
     delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/NeighborhoodRepository.ts
+++ b/backend/src/domain/repositories/NeighborhoodRepository.ts
@@ -1,10 +1,10 @@
 import { Neighborhood } from "../entities/Neighborhood.js";
 
 export interface NeighborhoodRepository {
-    create(data: Omit<Neighborhood, "id" | "created_at" | "updated_at">): Promise<Neighborhood>;
+    create(data: Omit<Neighborhood, "id" | "createdAt" | "updatedAt">): Promise<Neighborhood>;
     findById(id: number): Promise<Neighborhood | null>;
     findAll(): Promise<Neighborhood[]>;
     findByRouteId(routeId: number): Promise<Neighborhood[]>;
-    update(id: number, data: Partial<Omit<Neighborhood, "id" | "created_at">>): Promise<Neighborhood>;
+    update(id: number, data: Partial<Omit<Neighborhood, "id" | "createdAt">>): Promise<Neighborhood>;
     delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/ProblemReportRepository.ts
+++ b/backend/src/domain/repositories/ProblemReportRepository.ts
@@ -3,12 +3,12 @@ import { ProblemStatus } from "../value-objects/ProblemStatus.js";
 import { ProblemProtocol } from "../value-objects/ProblemProtocol.js";
 
 export interface ProblemReportRepository {
-  create(data: Omit<ProblemReport, "id" | "created_at" | "updated_at">): Promise<ProblemReport>;
+  create(data: Omit<ProblemReport, "id" | "createdAt" | "updatedAt">): Promise<ProblemReport>;
   findById(id: number): Promise<ProblemReport | null>;
   findByProtocol(protocol: ProblemProtocol): Promise<ProblemReport | null>;
   findBySubscriberId(subscriberId: number): Promise<ProblemReport[]>;
   findAll(): Promise<ProblemReport[]>;
-  update(id: number, data: Partial<Omit<ProblemReport, "id" | "created_at">>): Promise<ProblemReport>;
+  update(id: number, data: Partial<Omit<ProblemReport, "id" | "createdAt">>): Promise<ProblemReport>;
   updateStatus(id: number, status: ProblemStatus, resolvedByAdminId?: number): Promise<ProblemReport | null>;
   delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/RouteRepository.ts
+++ b/backend/src/domain/repositories/RouteRepository.ts
@@ -1,9 +1,9 @@
 import { Route } from "../entities/Route.js";
 
 export interface RouteRepository {
-  create(data: Omit<Route, "id" | "created_at" | "updated_at">): Promise<Route>;
+  create(data: Omit<Route, "id" | "createdAt" | "updatedAt">): Promise<Route>;
   findById(id: number): Promise<Route | null>;
   findAll(): Promise<Route[]>;
-  update(id: number, data: Partial<Omit<Route, "id" | "created_at">>): Promise<Route>;
+  update(id: number, data: Partial<Omit<Route, "id" | "createdAt">>): Promise<Route>;
   delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/SubscriberRepository.ts
+++ b/backend/src/domain/repositories/SubscriberRepository.ts
@@ -2,11 +2,11 @@ import { Email } from "../value-objects/Email.js";
 import { Subscriber } from "../entities/Subscriber.js";
 
 export interface SubscriberRepository {
-    create(data: Omit<Subscriber, "id" | "created_at" | "updated_at">): Promise<Subscriber>;
+    create(data: Omit<Subscriber, "id" | "createdAt" | "updatedAt">): Promise<Subscriber>;
     findById(id: number): Promise<Subscriber | null>;
     findByEmail(email: Email): Promise<Subscriber | null>;
     findAll(): Promise<Subscriber[]>;
     findByNeighborhoodId(neighborhoodId: number): Promise<Subscriber[]>;
-    update(id: number, data: Partial<Omit<Subscriber, "id" | "created_at">>): Promise<Subscriber>;
+    update(id: number, data: Partial<Omit<Subscriber, "id" | "createdAt">>): Promise<Subscriber>;
     delete(id: number): Promise<void>;
 }

--- a/backend/src/infrastructure/database/prisma/PrismaAdministratorRepository.ts
+++ b/backend/src/infrastructure/database/prisma/PrismaAdministratorRepository.ts
@@ -6,7 +6,7 @@ import { Email } from "../../../domain/value-objects/Email.js";
 export class PrismaAdministratorRepository implements AdministratorRepository {
   constructor(private prisma: PrismaClient) { }
 
-  async create(data: Omit<Administrator, "id" | "creation_date" | "update_date">): Promise<Administrator> {
+  async create(data: Omit<Administrator, "id" | "creationDate" | "updateDate">): Promise<Administrator> {
     const createdAdmin = await this.prisma.administrador.create({
       data: {
         name: data.name,
@@ -75,7 +75,7 @@ export class PrismaAdministratorRepository implements AdministratorRepository {
     );
   }
 
-  async update(id: number, data: Partial<Omit<Administrator, "id" | "creation_date">>): Promise<Administrator> {
+  async update(id: number, data: Partial<Omit<Administrator, "id" | "creationDate">>): Promise<Administrator> {
     const updatedAdmin = await this.prisma.administrador.update({
       where: { id },
       data: {

--- a/backend/src/infrastructure/database/prisma/PrismaEcopointRepository.ts
+++ b/backend/src/infrastructure/database/prisma/PrismaEcopointRepository.ts
@@ -16,7 +16,7 @@ export class PrismaEcopointRepository implements EcopointRepository {
         return new CollectionTime(startTime.trim(), endTime.trim());
     }
 
-    async create(data: Omit<Ecopoint, "id" | "created_at" | "updated_at">): Promise<Ecopoint> {
+    async create(data: Omit<Ecopoint, "id" | "createdAt" | "updatedAt">): Promise<Ecopoint> {
         const createdEcopoint = await this.prisma.ecopoint.create({
             data: {
                 name: data.name,
@@ -26,12 +26,12 @@ export class PrismaEcopointRepository implements EcopointRepository {
                 postal_code: data.address.getPostalCode()?.getValue(),
                 latitude: data.address.getGeoLocation()?.getLatitude(),
                 longitude: data.address.getGeoLocation()?.getLongitude(),
-                accepted_materials: data.accepted_materials.toString(),
-                collection_days: data.collection_days.toString(),
-                collection_time: data.collection_time.getFormattedInterval(),
-                neighborhood_id: data.neighborhood_id,
-                admin_id_created: data.admin_id_created,
-                admin_id_updated: data.admin_id_updated,
+                accepted_materials: data.acceptedMaterials.toString(),
+                collection_days: data.collectionDays.toString(),
+                collection_time: data.collectionTime.getFormattedInterval(),
+                neighborhood_id: data.neighborhoodId,
+                admin_id_created: data.adminIdCreated,
+                admin_id_updated: data.adminIdUpdated,
             },
         });
 
@@ -148,7 +148,7 @@ export class PrismaEcopointRepository implements EcopointRepository {
         );
     }
 
-    async update(id: number, data: Partial<Omit<Ecopoint, "id" | "created_at">>): Promise<Ecopoint> {
+    async update(id: number, data: Partial<Omit<Ecopoint, "id" | "createdAt">>): Promise<Ecopoint> {
         const updatedEcopoint = await this.prisma.ecopoint.update({
             where: { id },
             data: {
@@ -159,12 +159,12 @@ export class PrismaEcopointRepository implements EcopointRepository {
                 postal_code: data.address?.getPostalCode()?.getValue(),
                 latitude: data.address?.getGeoLocation()?.getLatitude(),
                 longitude: data.address?.getGeoLocation()?.getLongitude(),
-                accepted_materials: data.accepted_materials?.toString(),
-                collection_days: data.collection_days?.toString(),
-                collection_time: data.collection_time?.getFormattedInterval(),
-                neighborhood_id: data.neighborhood_id,
-                admin_id_created: data.admin_id_created,
-                admin_id_updated: data.admin_id_updated,
+                accepted_materials: data.acceptedMaterials?.toString(),
+                collection_days: data.collectionDays?.toString(),
+                collection_time: data.collectionTime?.getFormattedInterval(),
+                neighborhood_id: data.neighborhoodId,
+                admin_id_created: data.adminIdCreated,
+                admin_id_updated: data.adminIdUpdated,
             },
         });
 

--- a/backend/src/infrastructure/database/prisma/PrismaNeighborhoodRepository.ts
+++ b/backend/src/infrastructure/database/prisma/PrismaNeighborhoodRepository.ts
@@ -8,7 +8,7 @@ import { GeoLocation } from "../../../domain/value-objects/GeoLocation.js";
 export class PrismaNeighborhoodRepository implements NeighborhoodRepository {
     constructor(private prisma: PrismaClient) { }
 
-    async create(data: Omit<Neighborhood, "id" | "created_at" | "updated_at">): Promise<Neighborhood> {
+    async create(data: Omit<Neighborhood, "id" | "createdAt" | "updatedAt">): Promise<Neighborhood> {
         const createdNeighborhood = await this.prisma.neighborhood.create({
             data: {
                 name: data.name,
@@ -16,9 +16,9 @@ export class PrismaNeighborhoodRepository implements NeighborhoodRepository {
                 cep: data.postalCode.getValue(),
                 latitude: data.geoLocation.getLatitude(),
                 longitude: data.geoLocation.getLongitude(),
-                route_id: data.route_id,
-                admin_id_created: data.admin_id_created,
-                admin_id_updated: data.admin_id_updated,
+                route_id: data.routeId,
+                admin_id_created: data.adminIdCreated,
+                admin_id_updated: data.adminIdUpdated,
             },
         });
 
@@ -99,7 +99,7 @@ export class PrismaNeighborhoodRepository implements NeighborhoodRepository {
         );
     }
 
-    async update(id: number, data: Partial<Omit<Neighborhood, "id" | "created_at">>): Promise<Neighborhood> {
+    async update(id: number, data: Partial<Omit<Neighborhood, "id" | "createdAt">>): Promise<Neighborhood> {
         const updatedNeighborhood = await this.prisma.neighborhood.update({
             where: { id },
             data: {
@@ -108,8 +108,8 @@ export class PrismaNeighborhoodRepository implements NeighborhoodRepository {
                 cep: data.postalCode?.getValue(),
                 latitude: data.geoLocation?.getLatitude(),
                 longitude: data.geoLocation?.getLongitude(),
-                route_id: data.route_id,
-                admin_id_updated: data.admin_id_updated,
+                route_id: data.routeId,
+                admin_id_updated: data.adminIdUpdated,
             },
         });
 

--- a/backend/src/infrastructure/database/prisma/PrismaProblemReportRepository.ts
+++ b/backend/src/infrastructure/database/prisma/PrismaProblemReportRepository.ts
@@ -10,7 +10,7 @@ import { ProblemType } from "../../../domain/value-objects/ProblemType.js";
 export class PrismaProblemReportRepository implements ProblemReportRepository {
   constructor(private prisma: PrismaClient) { }
 
-  async create(data: Omit<ProblemReport, "id" | "created_at" | "updated_at">): Promise<ProblemReport> {
+  async create(data: Omit<ProblemReport, "id" | "createdAt" | "updatedAt">): Promise<ProblemReport> {
     const createdProblem = await this.prisma.reportedProblem.create({
       data: {
         protocol: data.protocol.getValue(),
@@ -18,8 +18,8 @@ export class PrismaProblemReportRepository implements ProblemReportRepository {
         status: data.status.getValue(),
         description: data.description.getValue(),
         problem_type: data.problemType.getValue(),
-        subscriber_id: data.subscriber_id,
-        resolved_by_admin_id: data.resolved_by_admin_id,
+        subscriber_id: data.subscriberId,
+        resolved_by_admin_id: data.resolvedByAdminId,
       },
     });
 
@@ -146,7 +146,7 @@ export class PrismaProblemReportRepository implements ProblemReportRepository {
     );
   }
 
-  async update(id: number, data: Partial<Omit<ProblemReport, "id" | "created_at">>): Promise<ProblemReport> {
+  async update(id: number, data: Partial<Omit<ProblemReport, "id" | "createdAt">>): Promise<ProblemReport> {
     const updatedProblem = await this.prisma.reportedProblem.update({
       where: { id },
       data: {
@@ -155,8 +155,8 @@ export class PrismaProblemReportRepository implements ProblemReportRepository {
         status: data.status?.getValue(),
         description: data.description?.getValue(),
         problem_type: data.problemType?.getValue(),
-        subscriber_id: data.subscriber_id,
-        resolved_by_admin_id: data.resolved_by_admin_id,
+        subscriber_id: data.subscriberId,
+        resolved_by_admin_id: data.resolvedByAdminId,
       },
     });
 

--- a/backend/src/infrastructure/database/prisma/PrismaRouteRepository.ts
+++ b/backend/src/infrastructure/database/prisma/PrismaRouteRepository.ts
@@ -13,15 +13,15 @@ export class PrismaRouteRepository implements RouteRepository {
     return new CollectionTime(startTime.trim(), endTime.trim());
   }
 
-  async create(data: Omit<Route, "id" | "created_at" | "updated_at">): Promise<Route> {
+  async create(data: Omit<Route, "id" | "createdAt" | "updatedAt">): Promise<Route> {
     const createdRoute = await this.prisma.route.create({
       data: {
         name: data.name,
-        collection_days: data.collection_days.toString(),
-        collection_time: data.collection_time.getFormattedInterval(),
-        collection_type: data.collection_type.getValue(),
-        admin_id_created: data.admin_id_created,
-        admin_id_updated: data.admin_id_updated,
+        collection_days: data.collectionDays.toString(),
+        collection_time: data.collectionTime.getFormattedInterval(),
+        collection_type: data.collectionType.getValue(),
+        admin_id_created: data.adminIdCreated,
+        admin_id_updated: data.adminIdUpdated,
       },
     });
 
@@ -77,15 +77,15 @@ export class PrismaRouteRepository implements RouteRepository {
     );
   }
 
-  async update(id: number, data: Partial<Omit<Route, "id" | "created_at">>): Promise<Route> {
+  async update(id: number, data: Partial<Omit<Route, "id" | "createdAt">>): Promise<Route> {
     const updatedRoute = await this.prisma.route.update({
       where: { id },
       data: {
         name: data.name,
-        collection_days: data.collection_days?.toString(),
-        collection_time: data.collection_time?.getFormattedInterval(),
-        collection_type: data.collection_type?.getValue(),
-        admin_id_updated: data.admin_id_updated,
+        collection_days: data.collectionDays?.toString(),
+        collection_time: data.collectionTime?.getFormattedInterval(),
+        collection_type: data.collectionType?.getValue(),
+        admin_id_updated: data.adminIdUpdated,
       },
     });
 

--- a/backend/src/infrastructure/database/prisma/PrismaSubscriberRepository.ts
+++ b/backend/src/infrastructure/database/prisma/PrismaSubscriberRepository.ts
@@ -9,7 +9,7 @@ import { GeoLocation } from "../../../domain/value-objects/GeoLocation.js";
 export class PrismaSubscriberRepository implements SubscriberRepository {
     constructor(private prisma: PrismaClient) { }
 
-    async create(data: Omit<Subscriber, "id" | "created_at" | "updated_at">): Promise<Subscriber> {
+    async create(data: Omit<Subscriber, "id" | "createdAt" | "updatedAt">): Promise<Subscriber> {
         const createdSubscriber = await this.prisma.subscriber.create({
             data: {
                 email: data.email.getValue(),
@@ -19,7 +19,7 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                 postal_code: data.address.getPostalCode()?.getValue(),
                 latitude: data.address.getGeoLocation()?.getLatitude(),
                 longitude: data.address.getGeoLocation()?.getLongitude(),
-                neighborhood_id: data.neighborhood_id,
+                neighborhood_id: data.neighborhoodId,
             },
         });
 
@@ -141,7 +141,7 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
         );
     }
 
-    async update(id: number, data: Partial<Omit<Subscriber, "id" | "created_at">>): Promise<Subscriber> {
+    async update(id: number, data: Partial<Omit<Subscriber, "id" | "createdAt">>): Promise<Subscriber> {
         const updatedSubscriber = await this.prisma.subscriber.update({
             where: { id },
             data: {
@@ -152,7 +152,7 @@ export class PrismaSubscriberRepository implements SubscriberRepository {
                 postal_code: data.address?.getPostalCode()?.getValue(),
                 latitude: data.address?.getGeoLocation()?.getLatitude(),
                 longitude: data.address?.getGeoLocation()?.getLongitude(),
-                neighborhood_id: data.neighborhood_id,
+                neighborhood_id: data.neighborhoodId,
             },
         });
 


### PR DESCRIPTION
### 🔨 Alterações realizadas
Buscando seguir a **convenção** das linguagens de programação padronizamos o nome de campos e atributos nos repositórios com **_CamelCase_**, enquanto utilizamos o padrão _**SnakeCase**_ para campos no banco de dados.

### ⚙️ Exemplo
Seguindo o padrão **CamelCase**:
- ``accepted_materials`` ➔ ``acceptedMaterials``
- ``collection_days`` ➔ ``collectionDays``

No banco de dados, seguindo **SnakeCase**, os campos ficaram como já estavam:
- ``accepted_materials`` / ``created_at`` / ``collection_time``

### 📌 Observações
- Código compilando sem erros.
- Artefatos atualizados e validados.
- Refatoração concluída com sucesso