### PR TITLE
Implementando base de exceções de persistência

### DIFF
--- a/backend/src/domain/errors/persistence/ConflictError.ts
+++ b/backend/src/domain/errors/persistence/ConflictError.ts
@@ -1,0 +1,12 @@
+import { PersistenceError } from "./PersistenceError.js";
+
+/**
+ * @class ConflictError
+ * @description Lançado quando ocorre um conflito de dados na persistência, 
+ * geralmente devido a violações de chaves únicas (ex: email já cadastrado).
+ */
+export class ConflictError extends PersistenceError {
+    constructor(message: string) {
+        super(message);
+    }
+}

--- a/backend/src/domain/errors/persistence/EntityNotFoundError.ts
+++ b/backend/src/domain/errors/persistence/EntityNotFoundError.ts
@@ -1,0 +1,12 @@
+import { PersistenceError } from "./PersistenceError.js";
+
+/**
+ * @class EntityNotFoundError
+ * @description Lançado quando uma entidade solicitada não existe no armazenamento.
+ * Reutilizável para qualquer entidade do domínio (Administrator, Ecopoint, etc).
+ */
+export class EntityNotFoundError extends PersistenceError {
+    constructor(entityName: string, identifier: string | number) {
+        super(`${entityName} com identificador '${identifier}' não foi encontrado.`);
+    }
+}

--- a/backend/src/domain/errors/persistence/PersistenceError.ts
+++ b/backend/src/domain/errors/persistence/PersistenceError.ts
@@ -1,0 +1,12 @@
+/**
+ * @abstract PersistenceError
+ * @description Classe base abstrata para todos os erros relacionados à camada de persistência.
+ * Garante que falhas de infraestrutura não vazem detalhes técnicos para o domínio.
+ */
+export abstract class PersistenceError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = this.constructor.name;
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+}


### PR DESCRIPTION
### 🔨 Alterações realizadas

Para manter a integridade do domínio e garantir mensagens consistentes, é necessário criar uma hierarquia de exceções específicas que representem falhas no ciclo de vida da persistência.
A partir dessa necessidade foi criada a pasta ``persistence``. Nela estão os arquivos que cuidam dessas execeções específicas que representam falhas no nível de persistência, na camada de infraestrutura:

- ``EntityNotFoundError``: Quando uma **entidade** solicitada **não existe** no armazenamento.
- ``ConflictError``: Quando ocorre um **conflito de dados** na persistência. Ex.: e-mail duplicado.
- ``PersistenceError``: Garante que **falhas de infraestrutura não vazem** para o domínio.

### 🎯 Resultado
Uma **hierarquia** de exceções de persistência **clara e consistente**, que abstraia erros técnicos e forneça mensagens orientadas ao domínio, **fortalecendo** a camada de repositórios e **evitando vazamento** de detalhes da infraestrutura.
