### PR TITLE
Adicionado Padronização dos Contratos de Exceção nos Repositórios

### DIFF
--- a/backend/src/domain/repositories/AdministratorRepository.ts
+++ b/backend/src/domain/repositories/AdministratorRepository.ts
@@ -2,10 +2,40 @@ import { Email } from "../value-objects/Email.js";
 import { Administrator } from "../entities/Administrator.js";
 
 export interface AdministratorRepository {
+  /**
+   * @throws {ConflictError} Se o e-mail já estiver em uso.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   create(admin: Omit<Administrator, "id" | "creationDate" | "updateDate">): Promise<Administrator>;
+  
+  /**
+   * Retorna null se o administrador não for encontrado.
+   * @description Retorna null se o administrador não for encontrado.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   findByEmail(email: Email): Promise<Administrator | null>;
-  findById(id: number): Promise<Administrator | null>;
+  
+  /**
+   * @throws {EntityNotFoundError} Se o administrador com o ID fornecido não existir.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
+  findById(id: number): Promise<Administrator>;
+
+  /**
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   findAll(): Promise<Administrator[]>;
+
+  /**
+   * @throws {EntityNotFoundError} Se o administrador não existir.
+   * @throws {ConflictError} Se tentar atualizar para um e-mail que já pertence a outro administrador.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   update(id: number, data: Partial<Omit<Administrator, "id" | "creationDate">>): Promise<Administrator>;
+
+  /**
+   * @throws {EntityNotFoundError} Se o administrador não existir para deleção.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/EcopointRepository.ts
+++ b/backend/src/domain/repositories/EcopointRepository.ts
@@ -1,10 +1,37 @@
 import { Ecopoint } from "../entities/Ecopoint.js";
 
 export interface EcopointRepository {
+    /**
+     * @throws {ConflictError} Se houver duplicidade de dados críticos.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     create(data: Omit<Ecopoint, "id" | "createdAt" | "updatedAt">): Promise<Ecopoint>;
-    findById(id: number): Promise<Ecopoint | null>;
+    
+    /**
+     * @throws {EntityNotFoundError} Se o ecoponto não for encontrado pelo ID.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
+    findById(id: number): Promise<Ecopoint>;
+    
+    /**
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     findAll(): Promise<Ecopoint[]>;
+    
+    /**
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     findByNeighborhoodId(neighborhoodId: number): Promise<Ecopoint[]>;
+    
+    /**
+     * @throws {EntityNotFoundError} Se o ecoponto não existir para atualização.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     update(id: number, data: Partial<Omit<Ecopoint, "id" | "createdAt">>): Promise<Ecopoint>;
+    
+    /**
+     * @throws {EntityNotFoundError} Se o ecoponto não existir para deleção.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/NeighborhoodRepository.ts
+++ b/backend/src/domain/repositories/NeighborhoodRepository.ts
@@ -1,10 +1,37 @@
 import { Neighborhood } from "../entities/Neighborhood.js";
 
 export interface NeighborhoodRepository {
+    /**
+     * @throws {ConflictError} Se houver conflito de nome ou localização geográfica.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     create(data: Omit<Neighborhood, "id" | "createdAt" | "updatedAt">): Promise<Neighborhood>;
-    findById(id: number): Promise<Neighborhood | null>;
+    
+    /**
+     * @throws {EntityNotFoundError} Se o bairro não for encontrado pelo ID.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
+    findById(id: number): Promise<Neighborhood>;
+    
+    /**
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     findAll(): Promise<Neighborhood[]>;
+    
+    /**
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     findByRouteId(routeId: number): Promise<Neighborhood[]>;
+    
+    /**
+     * @throws {EntityNotFoundError} Se o bairro não existir para atualização.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     update(id: number, data: Partial<Omit<Neighborhood, "id" | "createdAt">>): Promise<Neighborhood>;
+    
+    /**
+     * @throws {EntityNotFoundError} Se o bairro não existir para deleção.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/ProblemReportRepository.ts
+++ b/backend/src/domain/repositories/ProblemReportRepository.ts
@@ -3,12 +3,49 @@ import { ProblemStatus } from "../value-objects/ProblemStatus.js";
 import { ProblemProtocol } from "../value-objects/ProblemProtocol.js";
 
 export interface ProblemReportRepository {
+  /**
+   * @throws {ConflictError} Se houver conflito de protocolo.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   create(data: Omit<ProblemReport, "id" | "createdAt" | "updatedAt">): Promise<ProblemReport>;
-  findById(id: number): Promise<ProblemReport | null>;
+  
+  /**
+   * @throws {EntityNotFoundError} Se o relato não for encontrado pelo ID.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
+  findById(id: number): Promise<ProblemReport>;
+  
+  /**
+   * Retorna null se o relato de problema não for encontrado pelo protocolo.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   findByProtocol(protocol: ProblemProtocol): Promise<ProblemReport | null>;
+  
+  /**
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   findBySubscriberId(subscriberId: number): Promise<ProblemReport[]>;
+  
+  /**
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   findAll(): Promise<ProblemReport[]>;
+  
+  /**
+   * @throws {EntityNotFoundError} Se o relato não existir para atualização.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   update(id: number, data: Partial<Omit<ProblemReport, "id" | "createdAt">>): Promise<ProblemReport>;
-  updateStatus(id: number, status: ProblemStatus, resolvedByAdminId?: number): Promise<ProblemReport | null>;
+  
+  /**
+   * @throws {EntityNotFoundError} Se o relato não existir para atualização de status.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
+  updateStatus(id: number, status: ProblemStatus, resolvedByAdminId?: number): Promise<ProblemReport>;
+  
+  /**
+   * @throws {EntityNotFoundError} Se o relato não existir para deleção.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/RouteRepository.ts
+++ b/backend/src/domain/repositories/RouteRepository.ts
@@ -1,9 +1,32 @@
 import { Route } from "../entities/Route.js";
 
 export interface RouteRepository {
+  /**
+   * @throws {ConflictError} Se houver conflito de nome da rota.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   create(data: Omit<Route, "id" | "createdAt" | "updatedAt">): Promise<Route>;
-  findById(id: number): Promise<Route | null>;
+  
+  /**
+   * @throws {EntityNotFoundError} Se a rota não for encontrada pelo ID.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
+  findById(id: number): Promise<Route>;
+  
+  /**
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   findAll(): Promise<Route[]>;
+  
+  /**
+   * @throws {EntityNotFoundError} Se a rota não existir para atualização.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   update(id: number, data: Partial<Omit<Route, "id" | "createdAt">>): Promise<Route>;
+  
+  /**
+   * @throws {EntityNotFoundError} Se a rota não existir para deleção.
+   * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+   */
   delete(id: number): Promise<void>;
 }

--- a/backend/src/domain/repositories/SubscriberRepository.ts
+++ b/backend/src/domain/repositories/SubscriberRepository.ts
@@ -2,11 +2,44 @@ import { Email } from "../value-objects/Email.js";
 import { Subscriber } from "../entities/Subscriber.js";
 
 export interface SubscriberRepository {
+    /**
+     * @throws {ConflictError} Se o e-mail fornecido já estiver cadastrado.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     create(data: Omit<Subscriber, "id" | "createdAt" | "updatedAt">): Promise<Subscriber>;
-    findById(id: number): Promise<Subscriber | null>;
+    
+    /**
+     * @throws {EntityNotFoundError} Se o assinante não for encontrado pelo ID.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
+    findById(id: number): Promise<Subscriber>;
+    
+    /**
+     * Retorna null se o assinante não for encontrado pelo e-mail.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     findByEmail(email: Email): Promise<Subscriber | null>;
+    
+    /**
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     findAll(): Promise<Subscriber[]>;
+    
+    /**
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     findByNeighborhoodId(neighborhoodId: number): Promise<Subscriber[]>;
+    
+    /**
+     * @throws {EntityNotFoundError} Se o assinante não existir para atualização.
+     * @throws {ConflictError} Se o novo e-mail já estiver em uso por outro assinante.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     update(id: number, data: Partial<Omit<Subscriber, "id" | "createdAt">>): Promise<Subscriber>;
+    
+    /**
+     * @throws {EntityNotFoundError} Se o assinante não existir para deleção.
+     * @throws {PersistenceError} Se ocorrer uma falha técnica na persistência.
+     */
     delete(id: number): Promise<void>;
 }


### PR DESCRIPTION
## 📖 Contexto
Foi concluída a refatoração dos contratos de exceção nos repositórios, garantindo maior previsibilidade e isolamento da camada de domínio em relação às falhas técnicas de infraestrutura.

## 🆕 O que mudou
- **Contratos Explícitos**  
  Todos os métodos de repositório agora documentam via JSDoc `@throws` quais erros de domínio podem ser lançados (`EntityNotFoundError`, `ConflictError`).
  
- **Fim da Ambiguidade do Null**  
  Operações críticas (`findById`, `update`, `delete`) não retornam mais `| null`.  
  O retorno é sempre garantido: ou uma entidade válida, ou uma exceção de domínio.

- **Consistência**  
  Métodos de busca opcional (como `findByEmail`) continuam retornando `null`, preservando a semântica de "verificação de existência".

## 🚀 Próximos Passos
Como as interfaces foram alteradas, as implementações Prisma apresentarão erros de compilação.  
A etapa seguinte será refatorar os **PrismaRepositories** para capturar erros do banco e traduzi-los em exceções de domínio, eliminando os erros de build.

## ✅ Benefícios
- **Blindagem do Domínio**  
  A camada de domínio agora espera falhas técnicas de forma padronizada, sem exposição de detalhes internos.

- **Segurança**  
  Logs e códigos brutos do banco ficam encapsulados em `PersistenceError`, evitando vazamento de informações técnicas.

- **Contratos Claros**  
  Os *Use Cases* passam a lidar de forma explícita tanto com erros de negócio (`EntityNotFoundError`, `ConflictError`) quanto com erros de infraestrutura (`PersistenceError`).

---

✔️ **Status:** Refatoração concluída e contratos de exceção padronizados.  
📌 **Próxima ação:** Ajustar implementações Prisma para alinhar com os novos contratos.
